### PR TITLE
feat: now libertybans should support alt registration per server.

### DIFF
--- a/bans-api/src/main/java/space/arim/libertybans/api/select/PunishmentSelector.java
+++ b/bans-api/src/main/java/space/arim/libertybans/api/select/PunishmentSelector.java
@@ -1,6 +1,6 @@
 /*
  * LibertyBans
- * Copyright © 2022 Anand Beh
+ * Copyright © 2024 Anand Beh
  *
  * LibertyBans is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -76,6 +76,9 @@ public interface PunishmentSelector {
 	 * For example, if a ban would prevent a player from joining the server, the ban is said to be applicable to
 	 * the player's UUID and IP. It may be, the player's IP is banned, the player's UUID is banned,
 	 * or the player has played on a banned IP and that IP is banned  while strict address enforcement is enabled. <br>
+	 * <br>
+	 * For maximum accuracy, the UUID and IP address pair should be taken from an actual user who has logged on before.
+	 * Due to specifics in terms of how applicability is computed, some punishments
 	 * <br>
 	 * By default, the server's configured address strictness is used, but this may be changed if desired.
 	 *

--- a/bans-core/src/main/java/space/arim/libertybans/core/database/sql/ApplicableViewFields.java
+++ b/bans-core/src/main/java/space/arim/libertybans/core/database/sql/ApplicableViewFields.java
@@ -1,6 +1,6 @@
 /*
  * LibertyBans
- * Copyright © 2023 Anand Beh
+ * Copyright © 2024 Anand Beh
  *
  * LibertyBans is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -31,7 +31,6 @@ import space.arim.libertybans.api.punish.EscalationTrack;
 import space.arim.libertybans.core.scope.ScopeType;
 
 import java.time.Instant;
-import java.util.Objects;
 import java.util.UUID;
 
 public record ApplicableViewFields<R extends Record14<
@@ -111,7 +110,11 @@ public record ApplicableViewFields<R extends Record14<
 	}
 
 	public Field<UUID> uuid() {
-		return Objects.requireNonNull(fieldSupplier.field11(), "uuid field does not exist");
+		return fieldSupplier.field11();
+	}
+
+	public Field<NetworkAddress> address() {
+		return fieldSupplier.field12();
 	}
 
 }

--- a/bans-core/src/main/java/space/arim/libertybans/core/selector/EnforcementConfig.java
+++ b/bans-core/src/main/java/space/arim/libertybans/core/selector/EnforcementConfig.java
@@ -1,6 +1,6 @@
 /*
  * LibertyBans
- * Copyright © 2022 Anand Beh
+ * Copyright © 2024 Anand Beh
  *
  * LibertyBans is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -152,8 +152,8 @@ public interface EnforcementConfig {
 				"If you are planning to use this feature, make sure to have enabled 'enforce-server-switch' option."
 				})
 		@ConfKey("servers-without-ip-registration")
-		@DefaultStrings("")
-		List<String> servers();
+		@DefaultStrings({"auth"})
+		List<String> serversWithoutRegistration();
 
 		@ConfComments({"If you want to register the IP address of the player connecting, set this to true.",
 				"If you are running a Proxy and don't want to register the IP when players connect, ",

--- a/bans-core/src/main/java/space/arim/libertybans/core/selector/EnforcementConfig.java
+++ b/bans-core/src/main/java/space/arim/libertybans/core/selector/EnforcementConfig.java
@@ -140,6 +140,7 @@ public interface EnforcementConfig {
 
 	}
 
+	@ConfKey("alts-registry")
 	@SubSection
 	AltsRegistry altsRegistry();
 
@@ -147,18 +148,18 @@ public interface EnforcementConfig {
 	interface AltsRegistry {
 
 		@ConfComments({"The server names in this list will be excluded from associating the IP address of the player connecting.",
-				"Please note that the server's name of the list should be the same as the ones in your proxy config",
+				"Please note that the server's name in the list should be the same as the ones in your proxy configuration.",
 				"This is intended to be used by LibertyBans proxy installations.",
-				"If you are planning to use this feature, make sure to have enabled 'enforce-server-switch' option."
+				"If you are planning to use this feature, you MUST enable the 'enforce-server-switch' option."
 				})
 		@ConfKey("servers-without-ip-registration")
 		@DefaultStrings({"auth"})
 		List<String> serversWithoutRegistration();
 
 		@ConfComments({"If you want to register the IP address of the player connecting, set this to true.",
-				"If you are running a Proxy and don't want to register the IP when players connect, ",
-				"set this to false and add the auth server names in the list above.",
-				"If this is a backend server, then set it to false if it's an auth server, and true otherwise."})
+				"If you are running a proxy and don't want to register the IP when players connect, ",
+				"set this to false and add the authentication servers' names in the list above.",
+				"If this is a backend server, set it to false; if it's an authentication server, set to true."})
 		@ConfKey("should-register-on-connection)")
 		@ConfDefault.DefaultBoolean(true)
 		boolean shouldRegisterOnConnection();

--- a/bans-core/src/main/java/space/arim/libertybans/core/selector/EnforcementConfig.java
+++ b/bans-core/src/main/java/space/arim/libertybans/core/selector/EnforcementConfig.java
@@ -160,7 +160,7 @@ public interface EnforcementConfig {
 				"If you are running a proxy and don't want to register the IP when players connect, ",
 				"set this to false and add the authentication servers' names in the list above.",
 				"If this is a backend server, set it to false; if it's an authentication server, set to true."})
-		@ConfKey("should-register-on-connection)")
+		@ConfKey("should-register-on-connection")
 		@ConfDefault.DefaultBoolean(true)
 		boolean shouldRegisterOnConnection();
 	}

--- a/bans-core/src/main/java/space/arim/libertybans/core/selector/EnforcementConfig.java
+++ b/bans-core/src/main/java/space/arim/libertybans/core/selector/EnforcementConfig.java
@@ -148,7 +148,8 @@ public interface EnforcementConfig {
 
 		@ConfComments({"The server names in this list will be excluded from associating the IP address of the player connecting.",
 				"Please note that the server's name of the list should be the same as the ones in your proxy config",
-				"This is intended to be used by LibertyBans proxy installations."
+				"This is intended to be used by LibertyBans proxy installations.",
+				"If you are planning to use this feature, make sure to have enabled 'enforce-server-switch' option."
 				})
 		@ConfKey("servers-without-ip-registration")
 		@DefaultStrings("")

--- a/bans-core/src/main/java/space/arim/libertybans/core/selector/EnforcementConfig.java
+++ b/bans-core/src/main/java/space/arim/libertybans/core/selector/EnforcementConfig.java
@@ -146,23 +146,20 @@ public interface EnforcementConfig {
 	@ConfHeader({"Controls if all servers should register the IP address of the player connecting."})
 	interface AltsRegistry {
 
-		@ConfComments("If true, all servers will register alts.")
-		@ConfKey("enable-all")
-		@ConfDefault.DefaultBoolean(true)
-		boolean enableAll();
-
-		@ConfComments({"If enableAll is false, this list will be used ",
-				"to determine which servers will register alts.",
+		@ConfComments({"The server names in this list will be excluded from associating the IP address of the player connecting.",
 				"Please note that the server's name of the list should be the same as the ones in your proxy config",
-				"This is intended to be used by LibertyBans proxy installations.",
-				"If this is a backend server, please skip this option."})
-		@ConfKey("servers")
+				"This is intended to be used by LibertyBans proxy installations."
+				})
+		@ConfKey("servers-without-ip-registration")
 		@DefaultStrings("")
 		List<String> servers();
 
-		@ConfComments({"If true, this backend server will register alts"})
-		@ConfKey("should-register")
+		@ConfComments({"If you want to register the IP address of the player connecting, set this to true.",
+				"If you are running a Proxy and don't want to register the IP when players connect, ",
+				"set this to false and add the auth server names in the list above.",
+				"If this is a backend server, then set it to false if it's an auth server, and true otherwise."})
+		@ConfKey("should-register-on-connection)")
 		@ConfDefault.DefaultBoolean(true)
-		boolean shouldRegister();
+		boolean shouldRegisterOnConnection();
 	}
 }

--- a/bans-core/src/main/java/space/arim/libertybans/core/selector/EnforcementConfig.java
+++ b/bans-core/src/main/java/space/arim/libertybans/core/selector/EnforcementConfig.java
@@ -19,6 +19,7 @@
 
 package space.arim.libertybans.core.selector;
 
+import java.util.List;
 import java.util.Set;
 
 import space.arim.dazzleconf.annote.ConfComments;
@@ -137,5 +138,31 @@ public interface EnforcementConfig {
 		@NumericRange(min = 1)
 		long expirationTimeDays();
 
+	}
+
+	@SubSection
+	AltsRegistry altsRegistry();
+
+	@ConfHeader({"Controls if all servers should register the IP address of the player connecting."})
+	interface AltsRegistry {
+
+		@ConfComments("If true, all servers will register alts.")
+		@ConfKey("enable-all")
+		@ConfDefault.DefaultBoolean(true)
+		boolean enableAll();
+
+		@ConfComments({"If enableAll is false, this list will be used ",
+				"to determine which servers will register alts.",
+				"Please note that the server's name of the list should be the same as the ones in your proxy config",
+				"This is intended to be used by LibertyBans proxy installations.",
+				"If this is a backend server, please skip this option."})
+		@ConfKey("servers")
+		@DefaultStrings("")
+		List<String> servers();
+
+		@ConfComments({"If true, this backend server will register alts"})
+		@ConfKey("should-register")
+		@ConfDefault.DefaultBoolean(true)
+		boolean shouldRegister();
 	}
 }

--- a/bans-core/src/main/java/space/arim/libertybans/core/selector/Gatekeeper.java
+++ b/bans-core/src/main/java/space/arim/libertybans/core/selector/Gatekeeper.java
@@ -119,17 +119,16 @@ public final class Gatekeeper {
 
 	public CentralisedFuture<@Nullable Component> checkServerSwitch(UUID uuid, String name, NetworkAddress address,
 																	String destinationServer, ServerScope scope, SelectorImpl selector) {
+		if (!configs.getMainConfig().platforms().proxies().enforceServerSwitch()) {
+			return null;
+		}
 
 		return queryExecutor.get().queryWithRetry((context, transaction) -> {
 			boolean shouldRegister = configs.getMainConfig().enforcement().altsRegistry().shouldRegisterOnConnection();
 			List<String> servers = configs.getMainConfig().enforcement().altsRegistry().servers();
 
-			if (shouldRegister || !servers.contains(destinationServer)) {
+			if (!shouldRegister && !servers.contains(destinationServer)) {
 				doAssociation(uuid, name, address, time.currentTimestamp(), context);
-			}
-
-			if (!configs.getMainConfig().platforms().proxies().enforceServerSwitch()) {
-				return null;
 			}
 
 			return selector.selectionByApplicabilityBuilder(uuid, address)

--- a/bans-core/src/main/java/space/arim/libertybans/core/selector/Gatekeeper.java
+++ b/bans-core/src/main/java/space/arim/libertybans/core/selector/Gatekeeper.java
@@ -26,7 +26,6 @@ import org.jooq.DSLContext;
 import space.arim.libertybans.api.NetworkAddress;
 import space.arim.libertybans.api.PunishmentType;
 import space.arim.libertybans.api.punish.Punishment;
-import space.arim.libertybans.api.scope.ScopeManager;
 import space.arim.libertybans.api.scope.ServerScope;
 import space.arim.libertybans.api.select.SelectionPredicate;
 import space.arim.libertybans.api.select.SortPunishments;
@@ -57,12 +56,11 @@ public final class Gatekeeper {
 	private final AltDetection altDetection;
 	private final AltNotification altNotification;
 	private final Time time;
-	private final ScopeManager scopeManager;
 
 	@Inject
 	public Gatekeeper(Configs configs, FactoryOfTheFuture futuresFactory, Provider<QueryExecutor> queryExecutor,
 					  InternalFormatter formatter, ConnectionLimiter connectionLimiter, AltDetection altDetection,
-					  AltNotification altNotification, Time time, ScopeManager scopeManager) {
+					  AltNotification altNotification, Time time) {
 		this.configs = configs;
 		this.futuresFactory = futuresFactory;
 		this.queryExecutor = queryExecutor;
@@ -71,7 +69,6 @@ public final class Gatekeeper {
 		this.altDetection = altDetection;
 		this.altNotification = altNotification;
 		this.time = time;
-		this.scopeManager = scopeManager;
 	}
 
 	CentralisedFuture<Component> executeAndCheckConnection(UUID uuid, String name, NetworkAddress address,

--- a/bans-core/src/main/java/space/arim/libertybans/core/selector/Gatekeeper.java
+++ b/bans-core/src/main/java/space/arim/libertybans/core/selector/Gatekeeper.java
@@ -77,7 +77,6 @@ public final class Gatekeeper {
 			Instant currentTime = time.currentTimestamp();
 
 			EnforcementConfig config = configs.getMainConfig().enforcement();
-
 			if (config.altsRegistry().enableAll()) {
 				doAssociation(uuid, name, address, currentTime, context);
 

--- a/bans-core/src/main/java/space/arim/libertybans/core/selector/Guardian.java
+++ b/bans-core/src/main/java/space/arim/libertybans/core/selector/Guardian.java
@@ -35,9 +35,9 @@ public interface Guardian {
 	 * Adds the uuid and name to the local fast cache, queries for an applicable ban, and formats the
 	 * ban reason as the punishment message.
 	 *
-	 * @param uuid the player's uuid
-	 * @param name the player's name
-	 * @param address the player's network address
+	 * @param uuid       the player's uuid
+	 * @param name       the player's name
+	 * @param address    the player's network address
 	 * @return a future which yields the punishment message if denied, else null if allowed
 	 */
 	CentralisedFuture<@Nullable Component> executeAndCheckConnection(UUID uuid, String name, NetworkAddress address);
@@ -63,11 +63,27 @@ public interface Guardian {
 	 * Queries for an applicable ban, and formats the ban reason as the punishment message.
 	 *
 	 * @param uuid the player's uuid
+	 * @param name the player's name
 	 * @param address the player's network address
 	 * @param destinationServer the player's destination server
 	 * @return a future which yields the punishment message if denied, else null if allowed
 	 */
-	CentralisedFuture<@Nullable Component> checkServerSwitch(UUID uuid, InetAddress address, String destinationServer);
+	CentralisedFuture<@Nullable Component> checkServerSwitch(UUID uuid, String name, NetworkAddress address, String destinationServer);
+
+	/**
+	 * Enforces a server switch, returning a punishment message if denied, null if allowed. <br>
+	 * <br>
+	 * Queries for an applicable ban, and formats the ban reason as the punishment message.
+	 *
+	 * @param uuid the player's uuid
+	 * @param name the player's name
+	 * @param address the player's network address
+	 * @param destinationServer the player's destination server
+	 * @return a future which yields the punishment message if denied, else null if allowed
+	 */
+	default CentralisedFuture<@Nullable Component> checkServerSwitch(UUID uuid, String name, InetAddress address, String destinationServer) {
+		return checkServerSwitch(uuid, name, NetworkAddress.of(address), destinationServer);
+	}
 
 	/**
 	 * Enforces a chat message or executed command, returning a punishment message if denied, null if allowed. <br>

--- a/bans-core/src/main/java/space/arim/libertybans/core/selector/IntelligentGuardian.java
+++ b/bans-core/src/main/java/space/arim/libertybans/core/selector/IntelligentGuardian.java
@@ -32,7 +32,6 @@ import space.arim.libertybans.core.uuid.UUIDManager;
 import space.arim.omnibus.util.concurrent.CentralisedFuture;
 import space.arim.omnibus.util.concurrent.FactoryOfTheFuture;
 
-import java.net.InetAddress;
 import java.util.UUID;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;

--- a/bans-core/src/main/java/space/arim/libertybans/core/selector/IntelligentGuardian.java
+++ b/bans-core/src/main/java/space/arim/libertybans/core/selector/IntelligentGuardian.java
@@ -100,8 +100,7 @@ public final class IntelligentGuardian implements Guardian {
 																	String destinationServer) {
 		return selector
 				.executeAndCheckServerSwitch(
-						uuid, name, address,
-						scopeManager.specificScope(destinationServer), destinationServer
+						uuid, name, address, destinationServer
 				)
 				.toCompletableFuture()
 				.orTimeout(12, TimeUnit.SECONDS)

--- a/bans-core/src/main/java/space/arim/libertybans/core/selector/IntelligentGuardian.java
+++ b/bans-core/src/main/java/space/arim/libertybans/core/selector/IntelligentGuardian.java
@@ -24,9 +24,7 @@ import jakarta.inject.Singleton;
 import net.kyori.adventure.text.Component;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import space.arim.libertybans.api.NetworkAddress;
-import space.arim.libertybans.api.PunishmentType;
 import space.arim.libertybans.api.scope.ScopeManager;
-import space.arim.libertybans.api.select.SortPunishments;
 import space.arim.libertybans.core.config.Configs;
 import space.arim.libertybans.core.config.InternalFormatter;
 import space.arim.libertybans.core.selector.cache.MuteCache;
@@ -98,23 +96,13 @@ public final class IntelligentGuardian implements Guardian {
 	}
 
 	@Override
-	public CentralisedFuture<@Nullable Component> checkServerSwitch(UUID uuid, InetAddress address,
+	public CentralisedFuture<@Nullable Component> checkServerSwitch(UUID uuid, String name, NetworkAddress address,
 																	String destinationServer) {
-		if (!configs.getMainConfig().platforms().proxies().enforceServerSwitch()) {
-			return futuresFactory.completedFuture(null);
-		}
 		return selector
-				.selectionByApplicabilityBuilder(uuid, address)
-				.type(PunishmentType.BAN)
-				.scope(scopeManager.specificScope(destinationServer))
-				.build()
-				.getFirstSpecificPunishment(SortPunishments.LATEST_END_DATE_FIRST)
-				.thenCompose((punishment) -> {
-					if (punishment.isEmpty()) {
-						return futuresFactory.completedFuture(null);
-					}
-					return formatter.getPunishmentMessage(punishment.get());
-				})
+				.executeAndCheckServerSwitch(
+						uuid, name, address,
+						scopeManager.specificScope(destinationServer), destinationServer
+				)
 				.toCompletableFuture()
 				.orTimeout(12, TimeUnit.SECONDS)
 				.exceptionally(timeoutHandler("server switch"));

--- a/bans-core/src/main/java/space/arim/libertybans/core/selector/InternalSelector.java
+++ b/bans-core/src/main/java/space/arim/libertybans/core/selector/InternalSelector.java
@@ -59,10 +59,9 @@ public interface InternalSelector extends PunishmentSelector {
 	 * @param uuid		the player uuid
 	 * @param name		the player name
 	 * @param address	the player address
-	 * @param scope		the server scope to include in the selection query
 	 * @param destinationServer the server the player is switching to
 	 * @return a future which yields the denial message, or null if there is none
 	 */
 	CentralisedFuture<Component> executeAndCheckServerSwitch(UUID uuid, String name, NetworkAddress address,
-															 ServerScope scope, String destinationServer);
+															 String destinationServer);
 }

--- a/bans-core/src/main/java/space/arim/libertybans/core/selector/InternalSelector.java
+++ b/bans-core/src/main/java/space/arim/libertybans/core/selector/InternalSelector.java
@@ -42,14 +42,27 @@ public interface InternalSelector extends PunishmentSelector {
 	/**
 	 * Checks a player connection's in a single connection query, enforcing any applicable bans,
 	 * connection limits, and dealing out alt checks
-	 * 
-	 * @param uuid the player uuid
-	 * @param name the player name
-	 * @param address the player address
-	 * @param scopes the server scopes to include in the selection query
+	 *
+	 * @param uuid       the player uuid
+	 * @param name       the player name
+	 * @param address    the player address
+	 * @param scopes     the server scopes to include in the selection query
 	 * @return a future which yields the denial message, or null if there is none
 	 */
 	CentralisedFuture<Component> executeAndCheckConnection(UUID uuid, String name, NetworkAddress address,
 														   Set<ServerScope> scopes);
 
+	/**
+	 * Checks a player connection's in a single connection query, enforcing any applicable bans if
+	 * enforce server switch is enabled.
+	 *
+	 * @param uuid		the player uuid
+	 * @param name		the player name
+	 * @param address	the player address
+	 * @param scope		the server scope to include in the selection query
+	 * @param destinationServer the server the player is switching to
+	 * @return a future which yields the denial message, or null if there is none
+	 */
+	CentralisedFuture<Component> executeAndCheckServerSwitch(UUID uuid, String name, NetworkAddress address,
+															 ServerScope scope, String destinationServer);
 }

--- a/bans-core/src/main/java/space/arim/libertybans/core/selector/SelectionByApplicabilityBuilderImpl.java
+++ b/bans-core/src/main/java/space/arim/libertybans/core/selector/SelectionByApplicabilityBuilderImpl.java
@@ -1,6 +1,6 @@
 /*
  * LibertyBans
- * Copyright © 2023 Anand Beh
+ * Copyright © 2024 Anand Beh
  *
  * LibertyBans is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License as
@@ -39,6 +39,7 @@ public final class SelectionByApplicabilityBuilderImpl
 	private final NetworkAddress address;
 	private AddressStrictness strictness;
 	private final AddressStrictness defaultStrictness;
+	private boolean potentialNewEntrant;
 
 	SelectionByApplicabilityBuilderImpl(SelectionResources resources,
 										UUID uuid, NetworkAddress address, AddressStrictness defaultStrictness) {
@@ -68,7 +69,7 @@ public final class SelectionByApplicabilityBuilderImpl
 	@Override
 	SelectionByApplicability buildWith(SelectionBaseImpl.Details details) {
 		return new SelectionByApplicabilityImpl(
-				details, resources, uuid, address, strictness
+				details, resources, uuid, address, strictness, potentialNewEntrant
 		);
 	}
 
@@ -87,6 +88,19 @@ public final class SelectionByApplicabilityBuilderImpl
 	@Override
 	public SelectionByApplicabilityImpl build() {
 		return (SelectionByApplicabilityImpl) super.build();
+	}
+
+	/**
+	 * For internal use, to accomodate a new user whose UUID and IP address combination
+	 * has not yet been entered to the database. Sets whether this scenario is potential.
+	 *
+	 * @param canAssumeUserRecorded if the user is definitely registered, set to true. True by default.
+	 * @return this builder
+	 */
+	public SelectionByApplicabilityBuilderImpl canAssumeUserRecorded(boolean canAssumeUserRecorded) {
+		// A user is a potential new entrant if we can't assume they're recorded
+		this.potentialNewEntrant = !canAssumeUserRecorded;
+		return this;
 	}
 
 }

--- a/bans-core/src/main/java/space/arim/libertybans/core/selector/SelectorImpl.java
+++ b/bans-core/src/main/java/space/arim/libertybans/core/selector/SelectorImpl.java
@@ -26,6 +26,7 @@ import net.kyori.adventure.text.Component;
 import space.arim.libertybans.api.NetworkAddress;
 import space.arim.libertybans.api.PunishmentType;
 import space.arim.libertybans.api.punish.Punishment;
+import space.arim.libertybans.api.scope.ScopeManager;
 import space.arim.libertybans.api.scope.ServerScope;
 import space.arim.libertybans.api.select.AddressStrictness;
 import space.arim.libertybans.api.select.SelectionOrderBuilder;
@@ -47,15 +48,18 @@ public class SelectorImpl implements InternalSelector {
 	private final Gatekeeper gatekeeper;
 	private final Provider<MuteCache> muteCache;
 	private final SelectionResources resources;
+	private final ScopeManager scopeManager;
 
 	@Inject
 	public SelectorImpl(Configs configs, IDImpl idImpl, Gatekeeper gatekeeper,
-						Provider<MuteCache> muteCache, SelectionResources resources) {
+						Provider<MuteCache> muteCache, SelectionResources resources,
+						ScopeManager scopeManager) {
 		this.configs = configs;
 		this.idImpl = idImpl;
 		this.gatekeeper = gatekeeper;
 		this.muteCache = muteCache;
 		this.resources = resources;
+		this.scopeManager = scopeManager;
 	}
 
 	@Override
@@ -114,8 +118,9 @@ public class SelectorImpl implements InternalSelector {
 
 	@Override
 	public CentralisedFuture<Component> executeAndCheckServerSwitch(UUID uuid, String name, NetworkAddress address,
-																	ServerScope scope, String destinationServer) {
-		return gatekeeper.checkServerSwitch(uuid, name, address, destinationServer, scope, this);
+																	String destinationServer) {
+		return gatekeeper.checkServerSwitch(uuid, name, address, destinationServer,
+				scopeManager.specificScope(destinationServer), this);
 	}
 
 	@Override

--- a/bans-core/src/main/java/space/arim/libertybans/core/selector/SelectorImpl.java
+++ b/bans-core/src/main/java/space/arim/libertybans/core/selector/SelectorImpl.java
@@ -113,6 +113,12 @@ public class SelectorImpl implements InternalSelector {
 	}
 
 	@Override
+	public CentralisedFuture<Component> executeAndCheckServerSwitch(UUID uuid, String name, NetworkAddress address,
+																	ServerScope scope, String destinationServer) {
+		return gatekeeper.checkServerSwitch(uuid, name, address, destinationServer, scope, this);
+	}
+
+	@Override
 	public ReactionStage<Optional<Punishment>> getCachedMute(UUID uuid, NetworkAddress address) {
 		Objects.requireNonNull(uuid, "uuid");
 		Objects.requireNonNull(address, "address");

--- a/bans-env/bungee/src/main/java/space/arim/libertybans/env/bungee/ConnectionListener.java
+++ b/bans-env/bungee/src/main/java/space/arim/libertybans/env/bungee/ConnectionListener.java
@@ -108,7 +108,7 @@ public final class ConnectionListener implements Listener, PlatformListener {
 		InetAddress address = addressReporter.getAddress(player);
 
 		Component message = guardian.checkServerSwitch(
-				player.getUniqueId(), address, event.getTarget().getName()
+				player.getUniqueId(), player.getName(), address, event.getTarget().getName()
 		).join();
 		if (message != null) {
 			event.setCancelled(true);

--- a/bans-env/velocity/src/main/java/space/arim/libertybans/env/velocity/ConnectionListener.java
+++ b/bans-env/velocity/src/main/java/space/arim/libertybans/env/velocity/ConnectionListener.java
@@ -68,6 +68,7 @@ public final class ConnectionListener implements PlatformListener {
 			return null;
 		}
 		Player player = event.getPlayer();
+
 		return EventTask.resumeWhenComplete(guardian.executeAndCheckConnection(
 				player.getUniqueId(), player.getUsername(), player.getRemoteAddress().getAddress()
 		).thenAccept((message) -> {
@@ -91,7 +92,8 @@ public final class ConnectionListener implements PlatformListener {
 		}
 		Player player = event.getPlayer();
 		return EventTask.resumeWhenComplete(guardian.checkServerSwitch(
-				player.getUniqueId(), player.getRemoteAddress().getAddress(), destination.getServerInfo().getName()
+				player.getUniqueId(), player.getUsername(), player.getRemoteAddress().getAddress(),
+				destination.getServerInfo().getName()
 		).thenAccept((message) -> {
 			if (message != null) {
 				event.setResult(ServerPreConnectEvent.ServerResult.denied());

--- a/pom.xml
+++ b/pom.xml
@@ -570,5 +570,9 @@
 			<id>arim-mvn-gpl3</id>
 			<url>https://mvn-repo.arim.space/gpl3/</url>
 		</repository>
+		<repository>
+			<id>sonatype</id>
+			<url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+		</repository>
 	</repositories>
 </project>


### PR DESCRIPTION
This means that now you can choose whether all servers will register alts or only the selected ones. For proxies, you need to provide the names of the servers that you have in your configs, and for backends just enable or disable a setting in config.